### PR TITLE
Handle truncated album art images

### DIFF
--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -9,7 +9,7 @@ import sonos_user_data
 import sonos_settings
 import requests
 from io import BytesIO
-from PIL import ImageTk, Image
+from PIL import ImageTk, Image, ImageFile
 import os
 import demaster
 import scrap
@@ -46,6 +46,8 @@ previous_polled_trackname = ""
 thumbwidth = thumbsize[1]
 screenwidth = screensize[1]
 sonos_room = None
+
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 ###############################################################################
 # Functions


### PR DESCRIPTION
I found that when playing music from Plex, the album art images were sometimes truncated and would cause `OSError` exceptions when resizing. Seems to be an upstream issue with the Sonos<>Plex integration.

This relies on a feature to allow truncated images in the `pillow` versions of `PIL` which the recommended `python3-pil` package seems to provide. This displays the incomplete images as provided by the Sonos API without crashing the script.