### PR TITLE
Use albumArtUri if an absolute URI

### DIFF
--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -83,6 +83,11 @@ def current(sonos_room):
             return "", "", "", "", "API error"
         if 'artist' in obj['currentTrack']: current_artist = obj['currentTrack']['artist']
         if 'album' in obj['currentTrack']: current_album = obj['currentTrack']['album']
-        if 'absoluteAlbumArtUri' in obj['currentTrack']: current_image = obj['currentTrack']['absoluteAlbumArtUri']
+
+        album_art_uri = obj['currentTrack'].get('albumArtUri')
+        if album_art_uri and album_art_uri.startswith('http'):
+            current_image = album_art_uri
+        elif 'absoluteAlbumArtUri' in obj['currentTrack']:
+            current_image = obj['currentTrack']['absoluteAlbumArtUri']
 
     return current_trackname, current_artist, current_album, current_image, playing_status


### PR DESCRIPTION
When using the Plex cloud service to initiate playback on Sonos, the `albumArtUri` contents holds an absolute URI that holds the proper art, while `absoluteAlbumArtUri` does not provide the image contents. This prefers the `albumArtUri` if it actually returns an absolute URI.