### PR TITLE
Use requests timeouts, remove duplicate request

### DIFF
--- a/demaster.py
+++ b/demaster.py
@@ -47,8 +47,9 @@ def strip_name_api(full_song_name):
     print ("Checking API at "+  api_url)
 
     try:
-        r = requests.get(api_url)
-    except requests.ConnectionError:
+        r = requests.get(api_url, timeout=5)
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as err:
+        print ("Error contacting demaster host: " + err)
         short_song_name = "##Error##"
         request_error = True
         

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -109,7 +109,7 @@ def update():
 
             image_failed_to_load = False
             try:
-                image_url_response = requests.get(image_url)
+                image_url_response = requests.get(image_url, timeout=sonos_user_data.DEFAULT_TIMEOUT)
                 pil_image = Image.open(BytesIO(image_url_response.content))
             except:
                 pil_image = Image.open (sys.path[0] + "/sonos.png")

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -7,6 +7,8 @@ import json
 import sonos_settings
 import time
 
+DEFAULT_TIMEOUT = 5
+
 def find_unknown_radio_station_name(filename):
     # BBC streams started via alexa don't return their real name, which is annoying... but fixable:
     # if you find other stations which are not shown then you can add them below. Please put up on github will a pull request if you do
@@ -41,13 +43,12 @@ def current(sonos_room):
 
     # download the raw json object and parse the json data
     try:
-        data = requests.get(url)
-    except requests.ConnectionError:
+        data = requests.get(url, timeout=DEFAULT_TIMEOUT)
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
         print ("Error: http-sonos-api failed to answer; pausing 20 seconds to give it a chance to catch up")
         time.sleep (20)
         return "", "", "", "", "API error"
 
-    data = requests.get (url)
     obj = json.loads(data.text)
 
     # extract relevant data


### PR DESCRIPTION
A `timeout` parameter should always be used with `requests` calls as an unresponsive server can hang the request indefinitely: https://requests.readthedocs.io/en/master/user/quickstart/#timeouts. This adds a default timeout of 5s to all requests.

Also removes a seemingly redundant `requests.get()` call in `sonos_user_data.py`.