### PR TITLE
Webhook updating & async support

### DIFF
--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -55,10 +55,12 @@ screensize = 720,720  # pixel size of HyperPixel 4.0
 fullscreen = True
 
 # Declare global variables (don't mess with these)
-last_update_timestamp = 0
 previous_track = None
 thumbwidth = thumbsize[1]
 screenwidth = screensize[1]
+
+POLLING_INTERVAL = 1
+WEBHOOK_INTERVAL = 60
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
@@ -79,10 +81,7 @@ def set_backlight_power(new_state):
 
 async def redraw(session, sonos_data, tk_data):
     """Redraw the screen with current data."""
-    global last_update_timestamp
     global previous_track
-
-    last_update_timestamp = time.time()
 
     if sonos_data.status == "API error":
         if remote_debug_key != "": print ("API error reported fyi")
@@ -218,7 +217,6 @@ tk_data = TkData(root, detail_text, label_albumart, track_name)
 
 
 async def main(loop):
-    global last_update_timestamp
     if sonos_settings.room_name_for_highres == "":
         print ("No room name found in sonos_settings.py")
         print ("You can specify a room name manually below")
@@ -245,11 +243,11 @@ async def main(loop):
 
     while True:
         if sonos_data.webhook_active:
-            update_interval = 60
+            update_interval = WEBHOOK_INTERVAL
         else:
-            update_interval = 1
+            update_interval = POLLING_INTERVAL
 
-        if time.time() - last_update_timestamp > update_interval:
+        if time.time() - sonos_data.last_update > update_interval:
             await sonos_data.refresh()
             await redraw(session, sonos_data, tk_data)
         await asyncio.sleep(1)

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -1,5 +1,7 @@
-# This file is for use with the Pimoroni HyperPixel 4.0 Square (Non Touch) High Res display
-# it integrates with your local Sonos sytem to display what is currently playing
+"""
+This file is for use with the Pimoroni HyperPixel 4.0 Square (Non Touch) High Res display
+it integrates with your local Sonos sytem to display what is currently playing
+"""
 
 from aiohttp import ClientSession
 import asyncio
@@ -29,6 +31,7 @@ else:
 class TkData():
 
     def __init__(self, root, detail_text, label_albumart, track_name):
+        """Initialize the object."""
         self.root = root
         self.detail_text = detail_text
         self.label_albumart = label_albumart

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -93,13 +93,13 @@ async def update(session, sonos_data, tk_data):
     current_trackname = sonos_data.trackname
     current_artist = sonos_data.artist
     current_album = sonos_data.album
-    current_image = sonos_data.image
+    current_image_url = sonos_data.image
 
     # see if something is playing
     if sonos_data.status == "PLAYING":
         if remote_debug_key != "": print ("Music playing")
 
-        checksum = f"{current_trackname}-{current_artist}-{current_album}-{len(current_image)}"
+        checksum = f"{current_trackname}-{current_artist}-{current_album}-{current_image_url}"
         # check whether the track has changed - don't bother updating everything if not
         if checksum != previous_track:
             if remote_debug_key != "": print ("Current track " + current_trackname + " is not same as previous track " + previous_track)
@@ -116,11 +116,8 @@ async def update(session, sonos_data, tk_data):
             tk_data.track_name.set(current_trackname)
             tk_data.detail_text.set(current_artist + " • "+ current_album)
 
-            # pull the image from the uri provided
-            image_url = current_image
-
             try:
-                async with session.get(image_url) as response:
+                async with session.get(current_image_url) as response:
                     image_url_response = await response.read()
                 pil_image = Image.open(BytesIO(image_url_response))
             except:

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -3,20 +3,21 @@ This file is for use with the Pimoroni HyperPixel 4.0 Square (Non Touch) High Re
 it integrates with your local Sonos sytem to display what is currently playing
 """
 
-from aiohttp import ClientSession
 import asyncio
 import signal
-
-import tkinter as tk
-import tkinter.font as tkFont
-import time
 import sys
-from sonos_user_data import SonosData
-import sonos_settings
+import time
+import tkinter as tk
 from io import BytesIO
-from PIL import ImageTk, Image, ImageFile
+from tkinter import font as tkFont
+
+from aiohttp import ClientSession
+from PIL import Image, ImageFile, ImageTk
+
 import demaster
 import scrap
+import sonos_settings
+from sonos_user_data import SonosData
 from webhook_handler import SonosWebhook
 
 try:

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -96,19 +96,8 @@ async def redraw(session, sonos_data, tk_data):
     if sonos_data.status == "PLAYING":
         if remote_debug_key != "": print ("Music playing")
 
-        # Ignore update if all data is empty
-        if not any([current_album, current_artist, current_duration, current_trackname]):
+        if not sonos_data.is_track_new():
             return
-
-        # check whether the track has changed - don't bother updating everything if not
-        new_track_id = f"{current_trackname}|{current_artist}|{current_album}|{current_duration}"
-        if new_track_id == sonos_data.previous_track:
-            return
-
-        if remote_debug_key != "": print ("Current track " + new_track_id + " is not same as previous track " + sonos_data.previous_track)
-
-        # update previous trackname so we know what has changed in future
-        sonos_data.previous_track = new_track_id
 
         # slim down the trackname
         if sonos_settings.demaster:
@@ -147,7 +136,6 @@ async def redraw(session, sonos_data, tk_data):
         tk_data.track_name.set("")
         tk_data.detail_text.set("")
         tk_data.label_albumart.configure (image = "")
-        sonos_data.previous_track = None
         if remote_debug_key != "": print ("Track not playing - doing nothing")
 
     tk_data.root.update()

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -143,6 +143,7 @@ async def update(session, sonos_data, tk_data):
             set_backlight_power(True)
             tk_image = ImageTk.PhotoImage(pil_image)
             tk_data.label_albumart.configure (image = tk_image)
+            tk_data.root.update()
 
     else:
         set_backlight_power(False)
@@ -151,8 +152,8 @@ async def update(session, sonos_data, tk_data):
         tk_data.label_albumart.configure (image = "")
         previous_track = None
         if remote_debug_key != "": print ("Track not playing - doing nothing")
+        tk_data.root.update()
 
-    tk_data.root.update()
 
 def setup_tk():
     """Create the main Tk window."""

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -1,8 +1,7 @@
 # This file is for use with the Pimoroni HyperPixel 4.0 Square (Non Touch) High Res display
 # it integrates with your local Sonos sytem to display what is currently playing
 
-import aiohttp
-from aiohttp import web
+from aiohttp import ClientSession, web
 import asyncio
 import signal
 
@@ -234,7 +233,7 @@ async def main(loop):
         sonos_room = sonos_settings.room_name_for_highres
         print ("Sonos room name set as " + sonos_room + " from settings file")
 
-    session = aiohttp.ClientSession()
+    session = ClientSession()
     sonos_data = SonosData(sonos_room, session)
     tk_data = setup_tk()
 

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -92,6 +92,10 @@ async def redraw(session, sonos_data, tk_data):
     if sonos_data.status == "PLAYING":
         if remote_debug_key != "": print ("Music playing")
 
+        # Ignore update if all data is empty
+        if not any([current_album, current_artist, current_duration, current_trackname]):
+            return
+
         # check whether the track has changed - don't bother updating everything if not
         new_track_id = f"{current_trackname}|{current_artist}|{current_album}|{current_duration}"
         if new_track_id == sonos_data.previous_track:

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -55,7 +55,7 @@ screensize = 720,720  # pixel size of HyperPixel 4.0
 fullscreen = True
 
 # Declare global variables (don't mess with these)
-previous_polled_trackname = ""
+previous_track = None
 thumbwidth = thumbsize[1]
 screenwidth = screensize[1]
 
@@ -78,7 +78,7 @@ def set_backlight_power(new_state):
 
 # Read values from the sensors at regular intervals
 async def update(session, sonos_data, tk_data):
-    global previous_polled_trackname
+    global previous_track
 
     await sonos_data.refresh()
 
@@ -96,12 +96,13 @@ async def update(session, sonos_data, tk_data):
     if sonos_data.status == "PLAYING":
         if remote_debug_key != "": print ("Music playing")
 
+        checksum = f"{current_trackname}-{current_artist}-{current_album}-{len(current_image)}"
         # check whether the track has changed - don't bother updating everything if not
-        if current_trackname != previous_polled_trackname:
-            if remote_debug_key != "": print ("Current track " + current_trackname + " is not same as previous track " + previous_polled_trackname)
+        if checksum != previous_track:
+            if remote_debug_key != "": print ("Current track " + current_trackname + " is not same as previous track " + previous_track)
 
             # update previous trackname so we know what has changed in future
-            previous_polled_trackname = current_trackname
+            previous_track = checksum
 
             # slim down the trackname
             if sonos_settings.demaster:
@@ -144,7 +145,7 @@ async def update(session, sonos_data, tk_data):
         tk_data.track_name.set("")
         tk_data.detail_text.set("")
         tk_data.label_albumart.configure (image = "")
-        previous_polled_trackname = ""
+        previous_track = None
         if remote_debug_key != "": print ("Track not playing - doing nothing")
 
     tk_data.root.update()

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -152,73 +152,71 @@ async def update(session, sonos_data, tk_data):
     tk_data.root.update()
 
 
-def setup_tk():
-    """Create the main Tk window."""
-    # Create the main window
-    root = tk.Tk()
-    root.geometry("720x720")
-    root.title("Music Display")
+# Create the main window
+root = tk.Tk()
+root.geometry("720x720")
+root.title("Music Display")
 
-    # Create the main container
-    frame = tk.Frame(root, bg='black', width=720, height=720)
+# Create the main container
+frame = tk.Frame(root, bg='black', width=720, height=720)
 
-    # Lay out the main container (expand to fit window)
-    frame.pack(fill=tk.BOTH, expand=1)
+# Lay out the main container (expand to fit window)
+frame.pack(fill=tk.BOTH, expand=1)
 
-    # Set variables
-    track_name = tk.StringVar()
-    detail_text = tk.StringVar()
+# Set variables
+track_name = tk.StringVar()
+detail_text = tk.StringVar()
+if sonos_settings.show_artist_and_album:
+    track_font = tkFont.Font(family='Helvetica', size=30)
+else:
+    track_font = tkFont.Font(family='Helvetica', size=40)
+image_font = tkFont.Font(size=25)
+detail_font = tkFont.Font(family='Helvetica', size=15)
+
+# Create widgets
+label_albumart = tk.Label(frame,
+                        image = None,
+                        font=image_font,
+                        borderwidth=0,
+                        highlightthickness=0,
+                        fg='white',
+                        bg='black')
+label_track = tk.Label(frame,
+                        textvariable=track_name,
+                        font=track_font,
+                        fg='white',
+                        bg='black',
+                        wraplength=600,
+                        justify="center")
+label_detail = tk.Label(frame,
+                        textvariable=detail_text,
+                        font=detail_font,
+                        fg='white',
+                        bg='black',
+                        wraplength=600,
+                        justify="center")
+
+
+if sonos_settings.show_details == False:
+    label_albumart.place (relx=0.5, rely=0.5, anchor=tk.CENTER)
+
+if sonos_settings.show_details == True:
+    label_albumart.place(x=360, y=thumbsize[1]/2, anchor=tk.CENTER)
+    label_track.place (x=360, y=thumbsize[1]+20, anchor=tk.N)
+
+    label_track.update()
+    height_of_track_label = label_track.winfo_reqheight()
+
     if sonos_settings.show_artist_and_album:
-        track_font = tkFont.Font(family='Helvetica', size=30)
-    else:
-        track_font = tkFont.Font(family='Helvetica', size=40)
-    image_font = tkFont.Font(size=25)
-    detail_font = tkFont.Font(family='Helvetica', size=15)
+        label_detail.place (x=360, y=710, anchor=tk.S)
 
-    # Create widgets
-    label_albumart = tk.Label(frame,
-                            image = None,
-                            font=image_font,
-                            borderwidth=0,
-                            highlightthickness=0,
-                            fg='white',
-                            bg='black')
-    label_track = tk.Label(frame,
-                            textvariable=track_name,
-                            font=track_font,
-                            fg='white',
-                            bg='black',
-                            wraplength=600,
-                            justify="center")
-    label_detail = tk.Label(frame,
-                            textvariable=detail_text,
-                            font=detail_font,
-                            fg='white',
-                            bg='black',
-                            wraplength=600,
-                            justify="center")
+frame.grid_propagate(False)
 
+# Start in fullscreen mode
+root.attributes('-fullscreen', fullscreen)
+root.update()
 
-    if sonos_settings.show_details == False:
-        label_albumart.place (relx=0.5, rely=0.5, anchor=tk.CENTER)
-
-    if sonos_settings.show_details == True:
-        label_albumart.place(x=360, y=thumbsize[1]/2, anchor=tk.CENTER)
-        label_track.place (x=360, y=thumbsize[1]+20, anchor=tk.N)
-
-        label_track.update()
-        height_of_track_label = label_track.winfo_reqheight()
-
-        if sonos_settings.show_artist_and_album:
-            label_detail.place (x=360, y=710, anchor=tk.S)
-
-    frame.grid_propagate(False)
-
-    # Start in fullscreen mode
-    root.attributes('-fullscreen', fullscreen)
-    root.update()
-
-    return TkData(root, detail_text, label_albumart, track_name)
+tk_data = TkData(root, detail_text, label_albumart, track_name)
 
 
 async def main(loop):
@@ -236,7 +234,6 @@ async def main(loop):
 
     session = ClientSession()
     sonos_data = SonosData(sonos_room, session)
-    tk_data = setup_tk()
 
     webhook = SonosWebhook(sonos_data)
     await webhook.listen()

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -87,7 +87,6 @@ async def update(session, sonos_data, tk_data):
     await sonos_data.refresh()
 
     if sonos_data.status == "API error":
-        print("API error encountered")
         if remote_debug_key != "": print ("API error reported fyi")
         return
 

--- a/sonos_settings.py
+++ b/sonos_settings.py
@@ -7,6 +7,12 @@ sonos_http_api_port = "5005"
 
 demaster = True #crop song names to remove nonsense such as "Remastered" or "live at"
 
+## Webhook update support
+use_webhook = False
+# Set to True to use sonos-http-api webhooks to update on activity instead of polling.
+# Must update your sonos-http-api settings.json file to include: { "webhook": "http://localhost:8080/" }
+# If running sonos-http-api on a different machine, this device's IP should be used instead of 'localhost'.
+
 ## High-res only settings
 room_name_for_highres = ""   # the go_sonos_highres.py file cannot be reliably passed multi-word arguments on startup, so the room is defined here instead
 show_details = False   # if set to False then just shows the album art; if set to true then also displays track name + album/artist name

--- a/sonos_settings.py
+++ b/sonos_settings.py
@@ -7,12 +7,6 @@ sonos_http_api_port = "5005"
 
 demaster = True #crop song names to remove nonsense such as "Remastered" or "live at"
 
-## Webhook update support
-use_webhook = False
-# Set to True to use sonos-http-api webhooks to update on activity instead of polling.
-# Must update your sonos-http-api settings.json file to include: { "webhook": "http://localhost:8080/" }
-# If running sonos-http-api on a different machine, this device's IP should be used instead of 'localhost'.
-
 ## High-res only settings
 room_name_for_highres = ""   # the go_sonos_highres.py file cannot be reliably passed multi-word arguments on startup, so the room is defined here instead
 show_details = False   # if set to False then just shows the album art; if set to true then also displays track name + album/artist name

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -78,13 +78,8 @@ class SonosData():
 
             self.artist = ""
             self.album = ""
-
-            if 'absoluteAlbumArtUri' in obj['currentTrack']:
-                self.image = obj['currentTrack']['absoluteAlbumArtUri']
-            else:
-                self.image = ""
-
-        if type_playing != "radio":
+            self.image = obj['currentTrack'].get('absoluteAlbumArtUri', "")
+        else:
             self.trackname = obj['currentTrack'].get('title', "")
             self.artist = obj['currentTrack'].get('artist', "")
             self.album = obj['currentTrack'].get('album', "")
@@ -92,8 +87,8 @@ class SonosData():
             album_art_uri = obj['currentTrack'].get('albumArtUri')
             if album_art_uri and album_art_uri.startswith('http'):
                 self.image = album_art_uri
-            elif 'absoluteAlbumArtUri' in obj['currentTrack']:
-                self.image = obj['currentTrack']['absoluteAlbumArtUri']
+            else:
+                self.image = obj['currentTrack'].get('absoluteAlbumArtUri', "")
 
 
 def find_unknown_radio_station_name(filename):

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -2,10 +2,89 @@
 # if you're looking for that then try sonos_settings.py
 # sorry, I know it's confusingly named - but it's too late to change now!
 
-import requests
-import json
+import aiohttp
 import sonos_settings
-import time
+import urllib.parse
+
+DEFAULT_TIMEOUT = 5
+
+
+class SonosData():
+
+    def __init__(self, sonos_room, session):
+        self.sonos_room = sonos_room
+
+        self.trackname = ""
+        self.artist = ""
+        self.album = ""
+        self.image = ""
+        self.status = ""
+
+        self._data = None
+        self.session = session
+
+    async def refresh(self, payload=None):
+        """Refresh the Sonos media data with provided payload or a new get request."""
+        if payload:
+            obj = payload
+        else:
+            base_url = f"http://{sonos_settings.sonos_http_api_address}:{sonos_settings.sonos_http_api_port}"
+            url = urllib.parse.urljoin(base_url, f"{self.sonos_room}/state")
+
+            try:
+                async with self.session.get(url) as response:
+                    obj = await response.json()
+            except Exception as err:
+                self.status = "API error"
+                print(f"Error connecting to Sonos API: {err}")
+                return
+
+        try:
+            self.status = obj['playbackState']
+        except KeyError:
+            print("Error: http-sonos-api object is missing playbackState")
+            self.status = "API error"
+            return
+
+        type_playing = obj['currentTrack']['type']
+
+        # detect if its coming from Sonos radio, in which case forget that it's radio and pretend it's a normal track
+        uri = obj['currentTrack']['uri']
+        if uri.startswith('x-sonosapi-radio:sonos'):
+            type_playing = "sonos_radio"
+
+        if type_playing == "radio":
+
+            if 'stationName' in obj['currentTrack']:
+                # if Sonos has given us a nice station name then use that
+                self.trackname = obj['currentTrack']['stationName']
+            else:
+                # if not then try to look it up (usually because its played from Alexa)
+                self.trackname = str(find_unknown_radio_station_name(obj['currentTrack']['title']))
+
+            self.artist = ""
+            self.album = ""
+
+            if 'absoluteAlbumArtUri' in obj['currentTrack']:
+                self.image = obj['currentTrack']['absoluteAlbumArtUri']
+            else:
+                self.image = ""
+
+        if type_playing != "radio":
+            try:
+                self.trackname = obj['currentTrack']['title']
+            except:
+                self.status = "API error"
+                return
+            if 'artist' in obj['currentTrack']: self.artist = obj['currentTrack']['artist']
+            if 'album' in obj['currentTrack']: self.album = obj['currentTrack']['album']
+
+            album_art_uri = obj['currentTrack'].get('albumArtUri')
+            if album_art_uri and album_art_uri.startswith('http'):
+                self.image = album_art_uri
+            elif 'absoluteAlbumArtUri' in obj['currentTrack']:
+                self.image = obj['currentTrack']['absoluteAlbumArtUri']
+
 
 DEFAULT_TIMEOUT = 5
 
@@ -26,74 +105,3 @@ def find_unknown_radio_station_name(filename):
 
     # if not found:
     return "Radio"
-
-def current(sonos_room):
-    # reset all the variables so we return a blank if it's not set by the function
-    current_trackname = ""
-    current_artist = ""
-    current_album = ""
-    current_image =""
-    playing_status = ""
-
-    # convert any spaces to url-suitable character
-    sonos_room = sonos_room.replace(" ", "%20")
-
-    # build URL
-    url = "http://" + sonos_settings.sonos_http_api_address + ":" + sonos_settings.sonos_http_api_port + "/" + sonos_room + "/state"
-
-    # download the raw json object and parse the json data
-    try:
-        data = requests.get(url, timeout=DEFAULT_TIMEOUT)
-    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-        print ("Error: http-sonos-api failed to answer; pausing 20 seconds to give it a chance to catch up")
-        time.sleep (20)
-        return "", "", "", "", "API error"
-
-    obj = json.loads(data.text)
-
-    # extract relevant data
-    try:
-        playing_status = obj['playbackState']
-    except KeyError:
-        print ("Error: http-sonos-api object is missing playbackState")
-        time.sleep (10)
-        return "", "", "", "", "API error"
-    type_playing = obj['currentTrack']['type']
-
-    # detect if its coming from Sonos radio, in which case forget that it's radio and pretend it's a normal track
-    uri = obj['currentTrack']['uri']
-    if uri.startswith('x-sonosapi-radio:sonos'):
-        type_playing = "sonos_radio"
-
-    if type_playing == "radio":
-            
-        if 'stationName' in obj['currentTrack']:
-            # if Sonos has given us a nice station name then use that
-            current_trackname = obj['currentTrack']['stationName']
-        else:
-            # if not then try to look it up (usually because its played from Alexa)
-            current_trackname = str(find_unknown_radio_station_name(obj['currentTrack']['title']))
-        
-        current_artist = ""
-        current_album = ""
-        
-        if 'absoluteAlbumArtUri' in obj['currentTrack']:
-            current_image = obj['currentTrack']['absoluteAlbumArtUri']
-        else:
-            current_image = ""       
-
-    if type_playing != "radio":
-        try:
-            current_trackname = obj['currentTrack']['title']
-        except:
-            return "", "", "", "", "API error"
-        if 'artist' in obj['currentTrack']: current_artist = obj['currentTrack']['artist']
-        if 'album' in obj['currentTrack']: current_album = obj['currentTrack']['album']
-
-        album_art_uri = obj['currentTrack'].get('albumArtUri')
-        if album_art_uri and album_art_uri.startswith('http'):
-            current_image = album_art_uri
-        elif 'absoluteAlbumArtUri' in obj['currentTrack']:
-            current_image = obj['currentTrack']['absoluteAlbumArtUri']
-
-    return current_trackname, current_artist, current_album, current_image, playing_status

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 import sonos_settings
 
-WEBHOOK_TIMEOUT = 600   # 10 minutes
+WEBHOOK_TIMEOUT = 130
 
 
 class SonosData():
@@ -26,6 +26,12 @@ class SonosData():
         self.album = ""
         self.image = ""
         self.status = ""
+
+    @property
+    def last_update(self):
+        if self.last_webhook > self.last_poll:
+            return self.last_webhook
+        return self.last_poll
 
     async def refresh(self, payload=None):
         """Refresh the Sonos media data with provided payload or a new get request."""

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -68,6 +68,8 @@ class SonosData():
                 self.webhook_active = False
 
         type_playing = obj['currentTrack']['type']
+        self.artist = obj['currentTrack'].get('artist', "")
+        self.album = obj['currentTrack'].get('album', "")
         self.duration = obj['currentTrack']['duration']
 
         # detect if its coming from Sonos radio, in which case forget that it's radio and pretend it's a normal track
@@ -84,13 +86,9 @@ class SonosData():
                 # if not then try to look it up (usually because its played from Alexa)
                 self.trackname = str(find_unknown_radio_station_name(obj['currentTrack']['title']))
 
-            self.artist = ""
-            self.album = ""
             self.image = obj['currentTrack'].get('absoluteAlbumArtUri', "")
         else:
             self.trackname = obj['currentTrack'].get('title', "")
-            self.artist = obj['currentTrack'].get('artist', "")
-            self.album = obj['currentTrack'].get('album', "")
 
             album_art_uri = obj['currentTrack'].get('albumArtUri')
             if album_art_uri and album_art_uri.startswith('http'):

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -17,9 +17,9 @@ class SonosData():
         """Initialize the object."""
         self.last_poll = 0
         self.last_webhook = 0
-        self.session = session
         self.previous_track = None
         self.room = sonos_room
+        self.session = session
         self.webhook_active = False
 
         self.trackname = ""

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -71,13 +71,9 @@ class SonosData():
                 self.image = ""
 
         if type_playing != "radio":
-            try:
-                self.trackname = obj['currentTrack']['title']
-            except:
-                self.status = "API error"
-                return
-            if 'artist' in obj['currentTrack']: self.artist = obj['currentTrack']['artist']
-            if 'album' in obj['currentTrack']: self.album = obj['currentTrack']['album']
+            self.trackname = obj['currentTrack'].get('title', "")
+            self.artist = obj['currentTrack'].get('artist', "")
+            self.album = obj['currentTrack'].get('album', "")
 
             album_art_uri = obj['currentTrack'].get('albumArtUri')
             if album_art_uri and album_art_uri.startswith('http'):

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -18,6 +18,7 @@ class SonosData():
         self.last_poll = 0
         self.last_webhook = 0
         self.session = session
+        self.previous_track = None
         self.room = sonos_room
         self.webhook_active = False
 
@@ -67,6 +68,7 @@ class SonosData():
                 self.webhook_active = False
 
         type_playing = obj['currentTrack']['type']
+        self.duration = obj['currentTrack']['duration']
 
         # detect if its coming from Sonos radio, in which case forget that it's radio and pretend it's a normal track
         uri = obj['currentTrack']['uri']

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -2,11 +2,9 @@
 # if you're looking for that then try sonos_settings.py
 # sorry, I know it's confusingly named - but it's too late to change now!
 
-import aiohttp
-import sonos_settings
 import urllib.parse
 
-DEFAULT_TIMEOUT = 5
+import sonos_settings
 
 
 class SonosData():
@@ -81,8 +79,6 @@ class SonosData():
             elif 'absoluteAlbumArtUri' in obj['currentTrack']:
                 self.image = obj['currentTrack']['absoluteAlbumArtUri']
 
-
-DEFAULT_TIMEOUT = 5
 
 def find_unknown_radio_station_name(filename):
     # BBC streams started via alexa don't return their real name, which is annoying... but fixable:

--- a/webhook_handler.py
+++ b/webhook_handler.py
@@ -4,8 +4,9 @@ from aiohttp import web
 
 class SonosWebhook():
 
-    def __init__(self, sonos_data):
+    def __init__(self, sonos_data, callback):
         """Initialize the webhook handler."""
+        self.callback = callback
         self.runner = None
         self.sonos_data = sonos_data
 
@@ -23,6 +24,7 @@ class SonosWebhook():
         if json['type'] == 'transport-state':
             if json['data']['roomName'] == self.sonos_data.room:
                 await self.sonos_data.refresh(json['data']['state'])
+                await self.callback()
         return web.Response(text="hello")
 
     async def stop(self):

--- a/webhook_handler.py
+++ b/webhook_handler.py
@@ -1,0 +1,31 @@
+"""Helper class to handle webhook callbacks from node-sonos-http-api."""
+from aiohttp import web
+
+
+class SonosWebhook():
+
+    def __init__(self, sonos_data):
+        """Initialize the webhook handler."""
+        self.runner = None
+        self.sonos_data = sonos_data
+
+    async def listen(self):
+        """Start listening server."""
+        server = web.Server(self.handle)
+        self.runner = web.ServerRunner(server)
+        await self.runner.setup()
+        site = web.TCPSite(self.runner, 'localhost', 8080)
+        await site.start()
+
+    async def handle(self, request):
+        """Handle a webhook received from node-sonos-http-api."""
+        json = await request.json()
+        if json['type'] == 'transport-state':
+            if json['data']['roomName'] == self.sonos_data.room:
+                await self.sonos_data.refresh(json['data']['state'])
+        return web.Response(text="hello")
+
+    async def stop(self):
+        """Stop the listening server."""
+        if self.runner:
+            await self.runner.cleanup()


### PR DESCRIPTION
Sorry, this is a large potential PR. It has several changes that were somewhat dependent on each other:

- Support for [`node-sonos-http-api` webhooks](https://github.com/jishi/node-sonos-http-api#webhook). Instead of repeatedly polling every 500ms, this will only update in response to Sonos activity (and at least every 60 seconds just in case). This requires a `node-sonos-http-api` config change to enable the outgoing webhooks.
- Support for async. To more easily support the webhooks without threading, changed to an async loop model. Uses `aiohttp` instead of `requests`. New dependency that may need to be installed.
- Data structure changes. Most of the changes contain the same code, just moved into methods or classes. Eliminates the need for global variables and makes data passing a bit easier to understand.
- Fixes a couple of very minor bugs.

I've really only tested for my own use-cases. I'd appreciate if you'd give this branch a try and provide any feedback.

PS: I'm not super happy about using `tkinter` in an async context, but it's a non-interactive UI and I haven't run into any actual problems.