### PR TITLE
Fix failing autostart

### DIFF
--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -126,8 +126,8 @@ async def redraw(session, sonos_data, display):
 def log_git_hash():
     """Log the current git hash for troubleshooting purposes."""
     try:
-        git_hash = subprocess.check_output(["git", "describe"], text=True).strip()
-    except OSError as err:
+        git_hash = subprocess.check_output(["git", "describe"], cwd=sys.path[0], text=True).strip()
+    except (OSError, subprocess.CalledProcessError) as err:
         _LOGGER.debug("Error getting current version: %s", err)
     else:
         _LOGGER.info("Current script version: %s", git_hash)


### PR DESCRIPTION
Subprocess command assumed the script would run from the repo directory. This explicitly sets the cwd and catches another exception as a fallback.

Fixes: #36