### PR TITLE
Better handle unset DISPLAY env over SSH

### DIFF
--- a/display_controller.py
+++ b/display_controller.py
@@ -1,7 +1,9 @@
 """Implementation of the DisplayController class."""
 import logging
+import os
 import tkinter as tk
 from tkinter import font as tkFont
+import sys
 
 from PIL import ImageTk
 
@@ -32,7 +34,19 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
 
         self.backlight = Backlight()
 
-        self.root = tk.Tk()
+        try:
+            self.root = tk.Tk()
+        except tk.TclError:
+            self.root = None
+
+        if not self.root:
+            os.environ["DISPLAY"] = ":0"
+            try:
+                self.root = tk.Tk()
+            except tk.TclError as error:
+                _LOGGER.error("Cannot access display: %s", error)
+                sys.exit(1)
+
         self.root.geometry(f"{SCREEN_W}x{SCREEN_H}")
 
         self.album_frame = tk.Frame(

--- a/display_controller.py
+++ b/display_controller.py
@@ -3,7 +3,6 @@ import logging
 import os
 import tkinter as tk
 from tkinter import font as tkFont
-import sys
 
 from PIL import ImageTk
 
@@ -15,6 +14,10 @@ SCREEN_W = 720
 SCREEN_H = 720
 THUMB_W = 600
 THUMB_H = 600
+
+
+class SonosDisplaySetupError(Exception):
+    """Error connecting to Sonos display."""
 
 
 class DisplayController:  # pylint: disable=too-many-instance-attributes
@@ -45,7 +48,7 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
                 self.root = tk.Tk()
             except tk.TclError as error:
                 _LOGGER.error("Cannot access display: %s", error)
-                sys.exit(1)
+                raise SonosDisplaySetupError
 
         self.root.geometry(f"{SCREEN_W}x{SCREEN_H}")
 

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -15,7 +15,7 @@ from aiohttp import ClientError, ClientSession
 from PIL import Image, ImageFile
 
 import async_demaster
-from display_controller import DisplayController
+from display_controller import DisplayController, SonosDisplaySetupError
 from sonos_user_data import SonosData
 from webhook_handler import SonosWebhook
 
@@ -154,7 +154,11 @@ async def main(loop):
     setup_logging()
     log_git_hash()
     show_details_timeout = getattr(sonos_settings, "show_details_timeout", None)
-    display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout)
+    try:
+        display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout)
+    except SonosDisplaySetupError:
+        loop.stop()
+        return
 
     if sonos_settings.room_name_for_highres == "":
         print ("No room name found in sonos_settings.py")


### PR DESCRIPTION
Try to automatically handle situations like in #47 where the display is not linked to the current terminal session, such as when starting the script via SSH.