### PR TITLE
Fix show_artist_and_album behavior

### DIFF
--- a/display_controller.py
+++ b/display_controller.py
@@ -153,23 +153,18 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         self.label_albumart.configure(image=self.album_image)
         self.label_albumart_detail.configure(image=self.thumb_image)
 
-        detail_prefix = None
-        detail_suffix = sonos_data.album or None
+        detail_text = ""
+        display_trackname = sonos_data.trackname or sonos_data.station
 
-        if sonos_data.type == "radio":
-            display_trackname = sonos_data.trackname or sonos_data.station
-            self.track_name.set(display_trackname)
+        if self.show_artist_and_album:
+            detail_prefix = None
+            detail_suffix = sonos_data.album or None
 
-            if self.show_artist_and_album:
-                if sonos_data.artist != display_trackname:
-                    detail_prefix = sonos_data.artist
-
-        else:
-            display_trackname = sonos_data.trackname
-            if self.show_artist_and_album:
+            if sonos_data.artist != display_trackname:
                 detail_prefix = sonos_data.artist
 
-        detail_text = " • ".join(filter(None, [detail_prefix, detail_suffix]))
+            detail_text = " • ".join(filter(None, [detail_prefix, detail_suffix]))
+
         self.track_name.set(display_trackname)
         self.detail_text.set(detail_text)
         self.root.update_idletasks()


### PR DESCRIPTION
As mentioned in #46, the album was still displayed when `show_artist_and_album` was disabled.