### PR TITLE
Improvements to displaying Track Title, Album and Artist text

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A set of scripts to display current and recent music information.
 
 It uses either the Pimoroni wHAT e-ink display to display track information; or the Pimoroni HyperPixel 4.0 Square (Non Touch) High Res display to display full colour album art.
 
-[sonos-music-api Examples of Display Modes](https://user-images.githubusercontent.com/42817877/153659349-d239526e-fd87-4e4c-bc44-883e9454c4be.png)
+![sonos-music-api Examples of Display Modes](https://user-images.githubusercontent.com/42817877/153659349-d239526e-fd87-4e4c-bc44-883e9454c4be.png)
 
 Works in real time with your local Sonos sytem. Also includes functionality to pull last played tracks and music history from last.fm.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A set of scripts to display current and recent music information.
 
 It uses either the Pimoroni wHAT e-ink display to display track information; or the Pimoroni HyperPixel 4.0 Square (Non Touch) High Res display to display full colour album art.
 
-![Example of what it looks like](https://user-images.githubusercontent.com/25515609/84962206-370cf800-b0fe-11ea-99c9-b3546d847ecc.jpg)
+[sonos-music-api Examples of Display Modes](https://user-images.githubusercontent.com/42817877/153659349-d239526e-fd87-4e4c-bc44-883e9454c4be.png)
 
 Works in real time with your local Sonos sytem. Also includes functionality to pull last played tracks and music history from last.fm.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A set of scripts to display current and recent music information.
 
 It uses either the Pimoroni wHAT e-ink display to display track information; or the Pimoroni HyperPixel 4.0 Square (Non Touch) High Res display to display full colour album art.
 
-![sonos-music-api Examples of Display Modes](https://user-images.githubusercontent.com/42817877/153659349-d239526e-fd87-4e4c-bc44-883e9454c4be.png)
+![sonos-music-api Examples of Display Modes](https://user-images.githubusercontent.com/42817877/153710473-2fbe9534-b7d6-423e-8fd3-20193611c99e.png)
 
 Works in real time with your local Sonos sytem. Also includes functionality to pull last played tracks and music history from last.fm.
 

--- a/display_controller.py
+++ b/display_controller.py
@@ -195,7 +195,7 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
                 else:
                     self.track_font = tkFont.Font(family="Helvetica", size=30)
         else:
-            if len(display_trackname) > 25:
+            if len(display_trackname) > 20:
                 self.THUMB_H = 600
                 self.THUMB_W = 600
                 self.track_font = tkFont.Font(family="Helvetica", size=30)

--- a/display_controller.py
+++ b/display_controller.py
@@ -10,12 +10,8 @@ from hyperpixel_backlight import Backlight
 
 _LOGGER = logging.getLogger(__name__)
 
-
-
-
 class SonosDisplaySetupError(Exception):
     """Error connecting to Sonos display."""
-
 
 class DisplayController:  # pylint: disable=too-many-instance-attributes
     """Controller to handle the display hardware and GUI interface."""
@@ -25,8 +21,8 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         
         self.SCREEN_W = 720
         self.SCREEN_H = 720
-        self.THUMB_W = 620
-        self.THUMB_H = 620
+        self.THUMB_W = 0
+        self.THUMB_H = 0
         
         self.loop = loop
         self.show_details = show_details
@@ -77,10 +73,6 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         self.track_name = tk.StringVar()
         self.detail_text = tk.StringVar()
 
-        if show_artist_and_album:
-            self.track_font = tkFont.Font(family="Helvetica", size=30)
-        else:
-            self.track_font = tkFont.Font(family="Helvetica", size=40)
         self.detail_font = tkFont.Font(family="Helvetica", size=15)
 
         self.label_albumart = tk.Label(
@@ -104,7 +96,6 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         self.label_track = tk.Label(
             self.detail_frame,
             textvariable=self.track_name,
-            font=self.track_font,
             fg="white",
             bg="black",
             wraplength=600,
@@ -119,9 +110,6 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
             wraplength=600,
             justify="center",
         )
-        self.label_albumart_detail.place(relx=0.5, y=self.THUMB_H / 2, anchor=tk.CENTER)
-        self.label_track.place(relx=0.5, y=self.THUMB_H + 10, anchor=tk.N)
-        self.label_detail.place(relx=0.5, y=self.SCREEN_H - 10, anchor=tk.S)
 
         self.album_frame.grid_propagate(False)
         self.detail_frame.grid_propagate(False)
@@ -185,25 +173,36 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
 
         if self.show_artist_and_album:
             if len(display_trackname) > 30:
-                self.track_font = tkFont.Font(family="Helvetica", size=25)
-                if len(detail_text) >45:
+                if len(detail_text) > 45:
                     self.THUMB_H = 560
                     self.THUMB_W = 560
                 else:
                     self.THUMB_H = 580
                     self.THUMB_W = 580
+                if detail_text == "":
+                    self.track_font = tkFont.Font(family="Helvetica", size=30)
+                else:
+                    self.track_font = tkFont.Font(family="Helvetica", size=25)
             else:
-                self.track_font = tkFont.Font(family="Helvetica", size=30)
-                if len(detail_text) >45:
+                if len(detail_text) > 45:
                     self.THUMB_H = 600
                     self.THUMB_W = 600
                 else:
                     self.THUMB_H = 620
                     self.THUMB_W = 620
+                if detail_text == "":
+                    self.track_font = tkFont.Font(family="Helvetica", size=40)
+                else:
+                    self.track_font = tkFont.Font(family="Helvetica", size=30)
         else:
-            self.track_font = tkFont.Font(family="Helvetica", size=40)
-            self.THUMB_H = 620
-            self.THUMB_W = 620
+            if len(display_trackname) > 25:
+                self.THUMB_H = 600
+                self.THUMB_W = 600
+                self.track_font = tkFont.Font(family="Helvetica", size=30)
+            else:
+                self.THUMB_H = 620
+                self.THUMB_W = 620
+                self.track_font = tkFont.Font(family="Helvetica", size=40) 
         
         # Store the images as attributes to preserve scope for Tk
         self.album_image = resize_image(image, self.SCREEN_W)
@@ -211,7 +210,10 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
 
         self.label_albumart_detail.place(relx=0.5, y=self.THUMB_H / 2, anchor=tk.CENTER)
         self.label_track.place(relx=0.5, y=self.THUMB_H + 10, anchor=tk.N)
-        self.label_detail.place(relx=0.5, y=self.SCREEN_H - 10, anchor=tk.S)
+        if detail_text == "":
+            self.label_detail.place(relx=0.5, y=self.SCREEN_H + 10, anchor=tk.S)
+        else:
+            self.label_detail.place(relx=0.5, y=self.SCREEN_H - 10, anchor=tk.S)
 
         self.label_albumart.configure(image=self.album_image)
         self.label_albumart_detail.configure(image=self.thumb_image)

--- a/display_controller.py
+++ b/display_controller.py
@@ -177,8 +177,6 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
                 self.track_font = tkFont.Font(family="Helvetica", size=25)
                 self.THUMB_H = 580
                 self.THUMB_W = 580
-                print(display_trackname)
-
             else:
                 self.track_font = tkFont.Font(family="Helvetica", size=30)
                 self.THUMB_H = 600

--- a/display_controller.py
+++ b/display_controller.py
@@ -195,15 +195,23 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
                     self.track_font = tkFont.Font(family="Helvetica", size=40)
                 else:
                     self.track_font = tkFont.Font(family="Helvetica", size=30)
+            
+            if len(display_trackname) > 30 and len(display_trackname) < 42:
+                self.THUMB_H = self.THUMB_H + 30
+                self.THUMB_W = self.THUMB_W + 30
         else:
-            if len(display_trackname) > 20:
+            if len(display_trackname) > 22:
                 self.THUMB_H = 600
                 self.THUMB_W = 600
                 self.track_font = tkFont.Font(family="Helvetica", size=30)
             else:
                 self.THUMB_H = 620
                 self.THUMB_W = 620
-                self.track_font = tkFont.Font(family="Helvetica", size=40) 
+                self.track_font = tkFont.Font(family="Helvetica", size=40)
+
+            if len(display_trackname) > 22 and len(display_trackname) < 35:
+                self.THUMB_H = self.THUMB_H + 40
+                self.THUMB_W = self.THUMB_W + 40 
         
         # Store the images as attributes to preserve scope for Tk
         self.album_image = resize_image(image, self.SCREEN_W)
@@ -216,9 +224,20 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         
         self.label_track.place(relx=0.5, y=self.THUMB_H + 10, anchor=tk.N)
         if detail_text == "" or not self.show_artist_and_album:
-            self.label_detail.place(relx=0.5, y=self.SCREEN_H + 10, anchor=tk.S)
+            self.label_detail.destroy()
         else:
+            if self.label_detail.winfo_exists() == 0:
+                self.label_detail = tk.Label(
+                    self.detail_frame,
+                    textvariable=self.detail_text,
+                    font=self.detail_font,
+                    fg="white",
+                    bg="black",
+                    wraplength=600,
+                    justify="center",
+                )
             self.label_detail.place(relx=0.5, y=self.SCREEN_H - 10, anchor=tk.S)
+            self.label_detail.configure(font=self.detail_font)
 
         self.label_albumart.configure(image=self.album_image)
         self.label_albumart_detail.configure(image=self.thumb_image)
@@ -232,3 +251,5 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
     def cleanup(self):
         """Run cleanup actions."""
         self.backlight.cleanup()
+
+

--- a/display_controller.py
+++ b/display_controller.py
@@ -25,8 +25,8 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         
         self.SCREEN_W = 720
         self.SCREEN_H = 720
-        self.THUMB_W = 600
-        self.THUMB_H = 600
+        self.THUMB_W = 620
+        self.THUMB_H = 620
         
         self.loop = loop
         self.show_details = show_details
@@ -120,7 +120,7 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
             justify="center",
         )
         self.label_albumart_detail.place(relx=0.5, y=self.THUMB_H / 2, anchor=tk.CENTER)
-        self.label_track.place(relx=0.5, y=self.THUMB_H + 20, anchor=tk.N)
+        self.label_track.place(relx=0.5, y=self.THUMB_H + 10, anchor=tk.N)
         self.label_detail.place(relx=0.5, y=self.SCREEN_H - 10, anchor=tk.S)
 
         self.album_frame.grid_propagate(False)
@@ -165,39 +165,15 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
     def update(self, image, sonos_data):
         """Update displayed image and text."""
 
-        display_trackname = sonos_data.trackname or sonos_data.station
-
         def resize_image(image, length):
             """Resizes the image, assumes square image."""
             image = image.resize((length, length), ImageTk.Image.ANTIALIAS)
             return ImageTk.PhotoImage(image)
 
-        if self.show_artist_and_album:
-            if len(display_trackname) > 30:
-                self.track_font = tkFont.Font(family="Helvetica", size=25)
-                self.THUMB_H = 580
-                self.THUMB_W = 580
-            else:
-                self.track_font = tkFont.Font(family="Helvetica", size=30)
-                self.THUMB_H = 600
-                self.THUMB_W = 600
-        else:
-            self.track_font = tkFont.Font(family="Helvetica", size=30)
-        
-        # Store the images as attributes to preserve scope for Tk
-        self.album_image = resize_image(image, self.SCREEN_W)
-        self.thumb_image = resize_image(image, self.THUMB_W)
-
-        self.label_albumart_detail.place(relx=0.5, y=self.THUMB_H / 2, anchor=tk.CENTER)
-        self.label_track.place(relx=0.5, y=self.THUMB_H + 20, anchor=tk.N)
-        self.label_detail.place(relx=0.5, y=self.SCREEN_H - 10, anchor=tk.S)
-
-        self.label_albumart.configure(image=self.album_image)
-        self.label_albumart_detail.configure(image=self.thumb_image)
-        self.label_track.configure(font=self.track_font)
+        display_trackname = sonos_data.trackname or sonos_data.station
 
         detail_text = ""
-        
+
         if self.show_artist_and_album:
             detail_prefix = None
             detail_suffix = sonos_data.album or None
@@ -206,6 +182,40 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
                 detail_prefix = sonos_data.artist
 
             detail_text = " • ".join(filter(None, [detail_prefix, detail_suffix]))
+
+        if self.show_artist_and_album:
+            if len(display_trackname) > 30:
+                self.track_font = tkFont.Font(family="Helvetica", size=25)
+                if len(detail_text) >55:
+                    self.THUMB_H = 560
+                    self.THUMB_W = 560
+                else:
+                    self.THUMB_H = 580
+                    self.THUMB_W = 580
+            else:
+                self.track_font = tkFont.Font(family="Helvetica", size=30)
+                if len(detail_text) >45:
+                    self.THUMB_H = 600
+                    self.THUMB_W = 600
+                else:
+                    self.THUMB_H = 620
+                    self.THUMB_W = 620
+        else:
+            self.track_font = tkFont.Font(family="Helvetica", size=40)
+            self.THUMB_H = 620
+            self.THUMB_W = 620
+        
+        # Store the images as attributes to preserve scope for Tk
+        self.album_image = resize_image(image, self.SCREEN_W)
+        self.thumb_image = resize_image(image, self.THUMB_W)
+
+        self.label_albumart_detail.place(relx=0.5, y=self.THUMB_H / 2, anchor=tk.CENTER)
+        self.label_track.place(relx=0.5, y=self.THUMB_H + 10, anchor=tk.N)
+        self.label_detail.place(relx=0.5, y=self.SCREEN_H - 10, anchor=tk.S)
+
+        self.label_albumart.configure(image=self.album_image)
+        self.label_albumart_detail.configure(image=self.thumb_image)
+        self.label_track.configure(font=self.track_font)
 
         self.track_name.set(display_trackname)
         self.detail_text.set(detail_text)

--- a/display_controller.py
+++ b/display_controller.py
@@ -16,7 +16,7 @@ class SonosDisplaySetupError(Exception):
 class DisplayController:  # pylint: disable=too-many-instance-attributes
     """Controller to handle the display hardware and GUI interface."""
 
-    def __init__(self, loop, show_details, show_artist_and_album, show_details_timeout):
+    def __init__(self, loop, show_details, show_artist_and_album, show_details_timeout, overlay_text):
         """Initialize the display controller."""
         
         self.SCREEN_W = 720
@@ -28,6 +28,7 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         self.show_details = show_details
         self.show_artist_and_album = show_artist_and_album
         self.show_details_timeout = show_details_timeout
+        self.overlay_text = overlay_text
 
         self.album_image = None
         self.thumb_image = None
@@ -206,11 +207,15 @@ class DisplayController:  # pylint: disable=too-many-instance-attributes
         
         # Store the images as attributes to preserve scope for Tk
         self.album_image = resize_image(image, self.SCREEN_W)
-        self.thumb_image = resize_image(image, self.THUMB_W)
-
-        self.label_albumart_detail.place(relx=0.5, y=self.THUMB_H / 2, anchor=tk.CENTER)
+        if self.overlay_text:
+            self.thumb_image = resize_image(image, self.SCREEN_W)
+            self.label_albumart_detail.place(relx=0.5, rely=0.5, anchor=tk.CENTER)
+        else:
+            self.thumb_image = resize_image(image, self.THUMB_W)
+            self.label_albumart_detail.place(relx=0.5, y=self.THUMB_H / 2, anchor=tk.CENTER)
+        
         self.label_track.place(relx=0.5, y=self.THUMB_H + 10, anchor=tk.N)
-        if detail_text == "":
+        if detail_text == "" or not self.show_artist_and_album:
             self.label_detail.place(relx=0.5, y=self.SCREEN_H + 10, anchor=tk.S)
         else:
             self.label_detail.place(relx=0.5, y=self.SCREEN_H - 10, anchor=tk.S)

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -154,8 +154,9 @@ async def main(loop):
     setup_logging()
     log_git_hash()
     show_details_timeout = getattr(sonos_settings, "show_details_timeout", None)
+    
     try:
-        display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout)
+        display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout, sonos_settings.overlay_text)
     except SonosDisplaySetupError:
         loop.stop()
         return

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -154,9 +154,10 @@ async def main(loop):
     setup_logging()
     log_git_hash()
     show_details_timeout = getattr(sonos_settings, "show_details_timeout", None)
+    overlay_text = getattr(sonos_settings, "overlay_text", None)
     
     try:
-        display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout, sonos_settings.overlay_text)
+        display = DisplayController(loop, sonos_settings.show_details, sonos_settings.show_artist_and_album, show_details_timeout, overlay_text)
     except SonosDisplaySetupError:
         loop.stop()
         return

--- a/sonos_settings.py.example
+++ b/sonos_settings.py.example
@@ -36,6 +36,9 @@ show_artist_and_album = True
 # Display artist and album with track name with a new look. Ignored if 'show_details' is False.
 artist_and_album_newlook = True
 
+# Display Track, Album and Artist Information over fullscreen Album Art
+overlay_text = True
+
 # Turn off display (and backlight) when Sonos is playing from a TV source
 sleep_on_tv = False
 

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -101,6 +101,7 @@ class SonosData():
               if c :
                  oldstr=self.raw_trackname.casefold()
                  splitstr = oldstr.split(c)
+                 SplitStr = self.raw_trackname.split(c)
                  if self.raw_trackname.startswith("BR P|TYPE=SNG|") :
                     if self.raw_trackname == "BR P|TYPE=SNG|TITLE |ARTIST |ALBUM" :
                         if "bbc_radio" in self.uri :
@@ -109,8 +110,10 @@ class SonosData():
                             self.raw_trackname = self.station
                         self.artist = ""
                     else : 
-                        self.artist = ' '.join(word[0].upper() + word[1:] for word in splitstr[3].split())[6:]
-                        self.raw_trackname = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())[5:]
+                        #self.artist = ' '.join(word[0].upper() + word[1:] for word in splitstr[3].split())[6:]
+                        self.artist = SplitStr[3][6:]
+                        #self.raw_trackname = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())[5:]
+                        self.raw_trackname = SplitStr[2][5:]
                     if c == "~" :
                         self.album = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())
                     else :

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -83,6 +83,7 @@ class SonosData():
         self.artist = payload['currentTrack'].get('artist', "")
         self.album = payload['currentTrack'].get('album', "")
         self.station = payload['currentTrack'].get('stationName', "")
+        self.uri = payload['currentTrack'].get('uri', "")
 
         if sonos_settings.artist_and_album_newlook :
            if self.raw_trackname.startswith("x-sonosapi-") :
@@ -102,8 +103,11 @@ class SonosData():
                  splitstr = oldstr.split(c)
                  if self.raw_trackname.startswith("BR P|TYPE=SNG|") :
                     if self.raw_trackname == "BR P|TYPE=SNG|TITLE |ARTIST |ALBUM" :
-                        self.artist = self.station
-                        self.raw_trackname = ""
+                        if "bbc_radio" in self.uri :
+                            self.raw_trackname = "BBC " + self.station
+                        else :
+                            self.raw_trackname = self.station
+                        self.artist = ""
                     else : 
                         self.artist = ' '.join(word[0].upper() + word[1:] for word in splitstr[3].split())[6:]
                         self.raw_trackname = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())[5:]

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -111,9 +111,9 @@ class SonosData():
                         self.artist = ""
                     else : 
                         #self.artist = ' '.join(word[0].upper() + word[1:] for word in splitstr[3].split())[6:]
-                        self.artist = SplitStr[3][6:]
+                        self.artist = SplitStr[3][7:]
                         #self.raw_trackname = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())[5:]
-                        self.raw_trackname = SplitStr[2][5:]
+                        self.raw_trackname = SplitStr[2][6:]
                     if c == "~" :
                         self.album = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())
                     else :

--- a/sonos_user_data.py
+++ b/sonos_user_data.py
@@ -100,13 +100,26 @@ class SonosData():
               if c :
                  oldstr=self.raw_trackname.casefold()
                  splitstr = oldstr.split(c)
-                 self.artist = ' '.join(word[0].upper() + word[1:] for word in splitstr[0].split())
-                 self.raw_trackname = ' '.join(word[0].upper() + word[1:] for word in splitstr[1].split())
-                 if c == "~" :
-                    self.album = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())
+                 if self.raw_trackname.startswith("BR P|TYPE=SNG|") :
+                    if self.raw_trackname == "BR P|TYPE=SNG|TITLE |ARTIST |ALBUM" :
+                        self.artist = self.station
+                        self.raw_trackname = ""
+                    else : 
+                        self.artist = ' '.join(word[0].upper() + word[1:] for word in splitstr[3].split())[6:]
+                        self.raw_trackname = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())[5:]
+                    if c == "~" :
+                        self.album = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())
+                    else :
+                        self.album = ""
+    #                    self.album = self.station
                  else :
-                    self.album = ""
-#                    self.album = self.station
+                    self.artist = ' '.join(word[0].upper() + word[1:] for word in splitstr[0].split())
+                    self.raw_trackname = ' '.join(word[0].upper() + word[1:] for word in splitstr[1].split())
+                    if c == "~" :
+                        self.album = ' '.join(word[0].upper() + word[1:] for word in splitstr[2].split())
+                    else :
+                        self.album = ""
+    #                    self.album = self.station
 
         # Abort update if all data is empty
         if not any([self.album, self.artist, self.duration, self.station, self.raw_trackname]):


### PR DESCRIPTION
Adding in the ability to render the track title and artist information correctly from the BBC Sounds Service using the 'artist_and_album_newlook' setting set to true in sonos_settings.py 

Improving the placement and sizing of the track title, Album, and Art text to ensure all information can be seen if 'show_artist_and_album' is set to True in sonos_settings.py.

Adding the ability to overlay track title, Album, and Artist details over a fullscreen album art image. Requires a new parameter (overlay_text) to be set to True in sonos_settings.py, if set to False text is displayed below a thumbnail of the album art. This requires the inclusion of a new setting (overlay_text) set to true in sonos_settings.py, if it is set to False or is not present text will be displayed under the album art
![sonos-music-api Examples of Display Modes](https://user-images.githubusercontent.com/42817877/153711532-869190ef-9c9d-422f-b4c7-8a394233af7f.png)
.