### PR TITLE
Various non-critical bug fixes for Spotify Code and Artwork implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo gpasswd -a pi gpio
 
 # Displaying Spotify Codes or Using Spotify Album Art
 
-To display a Spotify Code or use Spotify album art instead of that loaded on to your Sonos system for the playing song, you need to insstall spotipy ([https://pypi.org/project/spotipy/](https://pypi.org/project/spotipy/)) a Spotify Developer account ([Information here](https://developer.spotify.com/)), as well as adding your Client_ID and client_SECRET into the `sonos_settings.py` file you need to set the `show_spotify_code` and/or `show_spotify_albumart` to True as below:
+To display a Spotify Code or use Spotify album art instead of that loaded on to your Sonos system for the playing song, you need to install spotipy ([https://pypi.org/project/spotipy/](https://pypi.org/project/spotipy/)) and setup a Spotify Developer account ([Information here](https://developer.spotify.com/)), as well as adding your Spotify API Client_ID and Spotify API client_SECRET into the `sonos_settings.py` file, you also need to set the `show_spotify_code` and/or `show_spotify_albumart` to True as below:
 ```
 #Spotify API Details
 spotify_client_id = ""
@@ -84,15 +84,13 @@ spotify_market = None
 # Show a Spotify Code graphic for the currently playing song if playing from Spotify
 show_spotify_code = True
 
-#Overide the albumart with that from Spotify if available
+#Overide the album art with that from Spotify if available
 show_spotify_albumart = True
 ```
 
-NOTE: You can localise the Spotify search to your country using the `spotify_market` setting in `sonos_settings.py` by `None` for one of the country codes recognised by the Spotify API ([Information Here](https://developer.spotify.com/documentation/web-api/reference/#/operations/search))
+NOTE: You can localise the Spotify search to your country using the `spotify_market` setting in `sonos_settings.py` by changing `None` to one of the country codes recognised by the Spotify API ([Information Here](https://developer.spotify.com/documentation/web-api/reference/#/operations/search))
 
-Spotipy expects to have access to a `.cache` file 
-
-If the script fails to execute on startup following the addition of yopur SPotify API detials and setting `show_spotify_code` and/or `show_spotify_albumart` to True, confirm if it is possible to manually execute the `go_sonos_highres.py` script using the following command from within the `music-screen-api` directory:
+If the script fails to execute on startup following the addition of yopur Spotify API details and setting `show_spotify_code` and/or `show_spotify_albumart` to True, confirm if it is possible to manually execute the `go_sonos_highres.py` script using the following command from within the `music-screen-api` directory:
 
 ```
 python3 go_sonos_highres.py
@@ -104,7 +102,7 @@ Open a command prompt:
 sudo nano /etc/xdg/lxsession/LXDE-pi/autostart
 ```
 
-Then it is necessary to stop executing `go_sonos_highres.py` sccript with sudo privileges by changing the following line at the end of the file that has opened, 
+Then it is necessary to stop executing `go_sonos_highres.py` script with sudo privileges by changing the following line at the end of the file that has opened: 
 
 from:
 ```
@@ -123,9 +121,9 @@ python3 spotipy_auth_search_test.py
 ```
 Enter an artist and song title when prompted to see if you can successfully search Spotify using spotipy
 
-Depending on your user permissions, using the above instructions to autostart the `go_sonos_highres.py` sccript may lead to numerous warning messages in the log file as Spotipy expects to have access to a `.cache` file in the directory the script was executed from. If this is the case the newly added `music-screen-api-startup.sh` script can be used instead:
+Depending on your user permissions, using the above instructions to autostart the `go_sonos_highres.py` script may lead to numerous warning messages in the log file as spotipy expects to have access to a `.cache` file in the directory the script was executed from. If this is the case the newly added `music-screen-api-startup.sh` script can be used instead:
 
-The contents of `music-screen-api-startup.sh` is
+The contents of `music-screen-api-startup.sh` is:
 ```
 cd ~/music-screen-api
 python3 go_sonos_highres.py
@@ -137,7 +135,7 @@ Open a command prompt:
 sudo nano /etc/xdg/lxsession/LXDE-pi/autostart
 ```
 
- It is then necessary to stop executing `go_sonos_highres.py` sccript directly by changing the following line at the end of the file that has opened, 
+ It is then necessary to stop executing `go_sonos_highres.py` script directly by changing the following line at the end of the file that has opened: 
 
 from:
 ```

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -99,14 +99,17 @@ async def redraw(session, sonos_data, display):
     # see if something is playing
     if sonos_data.status == "PLAYING":
         new_track_info = sonos_data.is_track_new()
+        force_update = False
 
-        if not sonos_data.is_track_new():
+        if not new_track_info:
             # Ensure the album frame is displayed in case the current track was paused, seeked, etc
             if not display.is_showing:
+                _LOGGER.debug("Waking up display...")
+                force_update = True
                 display.show_album()
 
-        if new_track_info:
-            _LOGGER.debug("The new_track_info state is %s, restting display with new information", new_track_info)
+        if new_track_info or force_update:
+            _LOGGER.debug("The new_track_info state is %s and force_update state is %s, resetting display with new information", new_track_info, force_update)
         
             # slim down the trackname
             if sonos_settings.demaster and sonos_data.type not in ["line_in", "TV"]:
@@ -143,9 +146,9 @@ async def redraw(session, sonos_data, display):
                             results = results['tracks']['items'][0]  # Find top result
                             uri = results['uri']
                             spotify_albumart_uri = results['album']['images'][0]['url']
-                            _LOGGER.debug("Spotify Code URI successfully obtained")
+                            _LOGGER.debug("Spotify album art URI successfully obtained: %s", spotify_albumart_uri)
                             spotify_code_uri = uri
-                            _LOGGER.debug("Spotify album art URI successfully obtained")
+                            _LOGGER.debug("Spotify Code URI successfully obtained: %s", spotify_code_uri)
                         else:
                             spotify_code_uri = None
                             spotify_albumart_uri = None 

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -174,7 +174,8 @@ async def redraw(session, sonos_data, display):
                 else:
                     code_image = None
             else:
-                _LOGGER.warning("No Spotify API client ID or Secret in settings file, cannot search the Spotify API")
+                if show_spotify_code or show_spotify_albumart:
+                    _LOGGER.warning("No Spotify API client ID or Secret in settings file, cannot search the Spotify API")
 
             if show_spotify_albumart and spotify_auth_success and spotify_albumart_uri != None:
                 image_data = await get_image_data(session, spotify_albumart_uri)

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -139,21 +139,26 @@ async def redraw(session, sonos_data, display):
                     if show_spotify_code or show_spotify_albumart and spotify_auth_success:
                         spotify_code_path = "https://scannables.scdn.co/uri/plain/png/368A7D/white/320/"
 
-                        results = spotify.search(q="artist:" + re.sub("´|`|'|’", "", sonos_data.artist) + " track:" + re.sub("´|`|'|’", "", sonos_data.trackname), type="track", limit=1, market=sonos_settings.spotify_market)
+                        try:
+                            results = spotify.search(q="artist:" + re.sub("´|`|'|’", "", sonos_data.artist) + " track:" + re.sub("´|`|'|’", "", sonos_data.trackname), type="track", limit=1, market=sonos_settings.spotify_market)
 
-                        if results['tracks']['total'] != 0:
-                            results = results['tracks']['items'][0]  # Find top result
-                            uri = results['uri']
-                            spotify_albumart_uri = results['album']['images'][0]['url']
-                            _LOGGER.debug("Spotify album art URI successfully obtained: %s", spotify_albumart_uri)
-                            if sonos_data.uri.startswith('x-sonos-spotify:'):
-                                spotify_code_uri = sonos_data.uri.replace('x-sonos-spotify:', '')
-                            else:                            
-                                spotify_code_uri = uri
-                            _LOGGER.debug("Spotify Code URI successfully obtained: %s", spotify_code_uri)
-                        else:
+                            if results['tracks']['total'] != 0:
+                                results = results['tracks']['items'][0]  # Find top result
+                                uri = results['uri']
+                                spotify_albumart_uri = results['album']['images'][0]['url']
+                                _LOGGER.debug("Spotify album art URI successfully obtained: %s", spotify_albumart_uri)
+                                if sonos_data.uri.startswith('x-sonos-spotify:'):
+                                    spotify_code_uri = sonos_data.uri.replace('x-sonos-spotify:', '')
+                                else:                            
+                                    spotify_code_uri = uri
+                                _LOGGER.debug("Spotify Code URI successfully obtained: %s", spotify_code_uri)
+                            else:
+                                spotify_code_uri = None
+                                spotify_albumart_uri = None
+                        except:
                             spotify_code_uri = None
-                            spotify_albumart_uri = None 
+                            spotify_albumart_uri = None
+                            _LOGGER.warning("Problem searching Spotify, defaulting to Sonos system")
 
                         if spotify_code_uri != None:
                             spotify_code_url = "".join(filter(None, [spotify_code_path, spotify_code_uri]))

--- a/go_sonos_highres.py
+++ b/go_sonos_highres.py
@@ -137,21 +137,22 @@ async def redraw(session, sonos_data, display):
             if spotify_client_id and spotify_client_secret:
                 if show_spotify_code or show_spotify_albumart and spotify_auth_success:
                     spotify_code_path = "https://scannables.scdn.co/uri/plain/png/368A7D/white/320/"
-                    if sonos_data.uri.startswith('x-sonos-spotify:'):
-                        spotify_code_uri = sonos_data.uri.replace('x-sonos-spotify:', '')
-                    else:
-                        results = spotify.search(q="artist:" + re.sub("´|`|'|’", "", sonos_data.artist) + " track:" + re.sub("´|`|'|’", "", sonos_data.trackname), type="track", limit=1, market=sonos_settings.spotify_market)
 
-                        if results['tracks']['total'] != 0:
-                            results = results['tracks']['items'][0]  # Find top result
-                            uri = results['uri']
-                            spotify_albumart_uri = results['album']['images'][0]['url']
-                            _LOGGER.debug("Spotify album art URI successfully obtained: %s", spotify_albumart_uri)
+                    results = spotify.search(q="artist:" + re.sub("´|`|'|’", "", sonos_data.artist) + " track:" + re.sub("´|`|'|’", "", sonos_data.trackname), type="track", limit=1, market=sonos_settings.spotify_market)
+
+                    if results['tracks']['total'] != 0:
+                        results = results['tracks']['items'][0]  # Find top result
+                        uri = results['uri']
+                        spotify_albumart_uri = results['album']['images'][0]['url']
+                        _LOGGER.debug("Spotify album art URI successfully obtained: %s", spotify_albumart_uri)
+                        if sonos_data.uri.startswith('x-sonos-spotify:'):
+                            spotify_code_uri = sonos_data.uri.replace('x-sonos-spotify:', '')
+                        else:                            
                             spotify_code_uri = uri
-                            _LOGGER.debug("Spotify Code URI successfully obtained: %s", spotify_code_uri)
-                        else:
-                            spotify_code_uri = None
-                            spotify_albumart_uri = None 
+                        _LOGGER.debug("Spotify Code URI successfully obtained: %s", spotify_code_uri)
+                    else:
+                        spotify_code_uri = None
+                        spotify_albumart_uri = None 
 
                     if spotify_code_uri != None:
                         spotify_code_url = "".join(filter(None, [spotify_code_path, spotify_code_uri]))


### PR DESCRIPTION
This pull request fixes a few non-critical bugs such as:

1. Ensuring the Spotify Code re-appears if the track is paused and restarted when the show_spotify_code setting is True
2. Improved error messaging to help with troubleshooting activities when the logging level is set to "debug"
3. Ensuring Spotify search is performed when playing tracks from Spotify when show_spotify_code and/or  show_spotify_albumart is True
4. Requiring text in the artist and trackname variables to perform a Spotify search 